### PR TITLE
add option fromdb

### DIFF
--- a/cmd/git-schemalex/main.go
+++ b/cmd/git-schemalex/main.go
@@ -15,6 +15,7 @@ import (
 var (
 	workspace = flag.String("workspace", "", "workspace of git")
 	deploy    = flag.Bool("deploy", false, "deploy")
+	fromdb    = flag.Bool("fromdb", false, "compare with db")
 	dsn       = flag.String("dsn", "", "")
 	table     = flag.String("table", "git_schemalex_version", "table of git revision")
 	schema    = flag.String("schema", "", "path to schema file")
@@ -50,6 +51,7 @@ func _main() error {
 		DSN:       *dsn,
 		Table:     *table,
 		Schema:    *schema,
+		FromDB:    *fromdb,
 	}
 	err := r.Run(ctx)
 	if err == gitschemalex.ErrEqualVersion {

--- a/gitschemalex_test.go
+++ b/gitschemalex_test.go
@@ -23,7 +23,6 @@ func TestRunner(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer mysqld.Stop()
-		t.Logf("Start OK %s", dsn)
 		dsn = mysqld.DSN()
 	}
 


### PR DESCRIPTION
ref https://github.com/schemalex/schemalex/pull/33

( sorry in japanese )

## 目的

データベースをあるべき状態に強制的に変更すること
その為、`-schema`オプションが示すsqlのコミット間の差分ではなく、実際のデータベースとあるべきスキーマとの差分を扱えるようにすること

### なぜ必要か

例えば、以下のようなケースでのリカバリを想定しています。
- migrateをしたけどUNIQ制約などによってADD COLUMNが出来ないような変更があった場合
   DDLはトランザクションが効かないため、一度migrateに失敗すると次回以降already existsなどが発生してしまう。
- うっかり手動で直接mysqlのスキーマを変更してしまった場合
  この場合もエラーが発生してしまったり、成功したとしても`-schama`にcreate table文を追加せず、手元のコードとDBだけを更新してしまったなどのケースも想定されます。


### 懸念点

versionteable以外のSchama管理していないテーブルを同じデータベースに入れている場合にdropしてしまうので、ignore tables みたいなオプションを用意したほうが良いでしょうか？

そもそも、git-schamalex-recovery みたいな別ツールにしたほうが良いでしょうか？

外部キー制約を使っていて、暗黙にINDEXが作成された時に、手書きのSQLとshow create tableで暗黙的に作成されたINDEXがdiffとなり、それがDROP INDEXできないという問題があったので外部キーを設定している場合 https://github.com/schemalex/schemalex/pull/33 だけでは足りなそうでした。
https://dev.mysql.com/doc/refman/5.6/ja/create-table-foreign-keys.html
この件についてはschemalexに別途prしようと思います。